### PR TITLE
Update to 2.1.1

### DIFF
--- a/Final_Project/RazorPagesMovie/Program.cs
+++ b/Final_Project/RazorPagesMovie/Program.cs
@@ -14,12 +14,11 @@ namespace RazorPagesMovie
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }

--- a/Final_Project/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/Final_Project/RazorPagesMovie/RazorPagesMovie.csproj
@@ -1,14 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
   </ItemGroup>
 </Project>
-

--- a/Final_Project/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/Final_Project/RazorPagesMovie/RazorPagesMovie.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/Final_Project/RazorPagesMovie/Startup.cs
+++ b/Final_Project/RazorPagesMovie/Startup.cs
@@ -7,9 +7,9 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using RazorPagesMovie.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using RazorPagesMovie.Models;
 
 namespace RazorPagesMovie
 {

--- a/Final_Project/RazorPagesMovie/Startup.cs
+++ b/Final_Project/RazorPagesMovie/Startup.cs
@@ -11,7 +11,6 @@ using RazorPagesMovie.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
-
 namespace RazorPagesMovie
 {
     public class Startup

--- a/Final_Project/RazorPagesMovie/Startup.cs
+++ b/Final_Project/RazorPagesMovie/Startup.cs
@@ -8,6 +8,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using RazorPagesMovie.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
 
 namespace RazorPagesMovie
 {
@@ -23,8 +26,16 @@ namespace RazorPagesMovie
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
             services.AddDbContext<MovieContext>(options => options.UseSqlite(Configuration.GetConnectionString("MovieContext")));
-            services.AddMvc();
+            services.AddMvc()
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);       
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -37,9 +48,12 @@ namespace RazorPagesMovie
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseHsts();
             }
 
             app.UseStaticFiles();
+            app.UseHttpsRedirection();
+            app.UseCookiePolicy();
 
             app.UseMvc(routes =>
             {

--- a/Tutorial/1-Create a Razor Page/RazorPagesMovie/Program.cs
+++ b/Tutorial/1-Create a Razor Page/RazorPagesMovie/Program.cs
@@ -14,12 +14,11 @@ namespace RazorPagesMovie
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }

--- a/Tutorial/1-Create a Razor Page/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/Tutorial/1-Create a Razor Page/RazorPagesMovie/RazorPagesMovie.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/Tutorial/1-Create a Razor Page/RazorPagesMovie/Startup.cs
+++ b/Tutorial/1-Create a Razor Page/RazorPagesMovie/Startup.cs
@@ -21,6 +21,13 @@ namespace RazorPagesMovie
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+                        
             services.AddMvc();
         }
 
@@ -34,9 +41,12 @@ namespace RazorPagesMovie
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseHsts();
             }
 
             app.UseStaticFiles();
+            app.UseHttpsRedirection();
+            app.UseCookiePolicy();
 
             app.UseMvc(routes =>
             {

--- a/Tutorial/2-Add a model/Addamodel.md
+++ b/Tutorial/2-Add a model/Addamodel.md
@@ -74,26 +74,6 @@ Open Startup.cs file and add the code below to the ConfigureServices method.
 ```
 Add the following using statements `using RazorPagesMovie.Models` and `using Microsoft.EntityFrameworkCore`.
 
-#### Add the Entity Framework tools 
-
-- Install the   `Microsoft.EntityFrameworkCore.Tools.DotNet` package to `DotNetCliToolReference` in RazorPagesMovie.csproj.
-
-```
-<Project Sdk="Microsoft.NET.Sdk.Web">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.1" />
-  </ItemGroup>
-</Project>
-
-```
 #### Add scaffold tooling and perform initial migration
 
 In the command line run the following commands
@@ -103,13 +83,13 @@ dotnet restore
 dotnet ef migrations add InitialCreate
 dotnet ef database update
 ```
-Commands Explained 
+Commands Explained
 
-| Command       |Description       | 
+| Command       |Description       |
 | ------------- |:-------------:|
 | ` add package`    | installs the tools needed |
-| `ef migrations add InitialCreate`     | generates code to create the initial database schema based on the model specified in 'MovieContenxt.cs'.`InitialCreate` is the name of the migrations. |  
-|`ef database update` | creates the database      | 
+| `ef migrations add InitialCreate`     | generates code to create the initial database schema based on the model specified in 'MovieContext.cs'. `InitialCreate` is the name of the migrations. |  
+|`ef database update` | creates the database      |
 
 #### Scaffold the movie model
 

--- a/Tutorial/2-Add a model/RazorPagesMovie/Program.cs
+++ b/Tutorial/2-Add a model/RazorPagesMovie/Program.cs
@@ -14,12 +14,11 @@ namespace RazorPagesMovie
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }

--- a/Tutorial/2-Add a model/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/Tutorial/2-Add a model/RazorPagesMovie/RazorPagesMovie.csproj
@@ -1,14 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
 </Project>
-

--- a/Tutorial/2-Add a model/RazorPagesMovie/Startup.cs
+++ b/Tutorial/2-Add a model/RazorPagesMovie/Startup.cs
@@ -23,8 +23,16 @@ namespace RazorPagesMovie
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
             services.AddDbContext<MovieContext>(options => options.UseSqlite(Configuration.GetConnectionString("MovieContext")));
-            services.AddMvc();
+            services.AddMvc()
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -40,7 +48,9 @@ namespace RazorPagesMovie
             }
 
             app.UseStaticFiles();
-
+            app.UseHttpsRedirection();
+            app.UseCookiePolicy();
+            
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/Tutorial/2-Add a model/RazorPagesMovie/Startup.cs
+++ b/Tutorial/2-Add a model/RazorPagesMovie/Startup.cs
@@ -45,6 +45,7 @@ namespace RazorPagesMovie
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseHsts();
             }
 
             app.UseStaticFiles();

--- a/Tutorial/3-Upate Pages/RazorPagesMovie/Program.cs
+++ b/Tutorial/3-Upate Pages/RazorPagesMovie/Program.cs
@@ -19,7 +19,6 @@ namespace RazorPagesMovie
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }

--- a/Tutorial/3-Upate Pages/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/Tutorial/3-Upate Pages/RazorPagesMovie/RazorPagesMovie.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
 </Project>
-

--- a/Tutorial/3-Upate Pages/RazorPagesMovie/Startup.cs
+++ b/Tutorial/3-Upate Pages/RazorPagesMovie/Startup.cs
@@ -23,8 +23,16 @@ namespace RazorPagesMovie
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
             services.AddDbContext<MovieContext>(options => options.UseSqlite(Configuration.GetConnectionString("MovieContext")));
-            services.AddMvc();
+            services.AddMvc()
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);       
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -37,9 +45,12 @@ namespace RazorPagesMovie
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseHsts();
             }
 
             app.UseStaticFiles();
+            app.UseHttpsRedirection();
+            app.UseCookiePolicy();
 
             app.UseMvc(routes =>
             {

--- a/Tutorial/4-Add Search/RazorPagesMovie/Program.cs
+++ b/Tutorial/4-Add Search/RazorPagesMovie/Program.cs
@@ -14,12 +14,11 @@ namespace RazorPagesMovie
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }

--- a/Tutorial/4-Add Search/RazorPagesMovie/RazorPagesMovie.csproj
+++ b/Tutorial/4-Add Search/RazorPagesMovie/RazorPagesMovie.csproj
@@ -1,14 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
   </ItemGroup>
 </Project>
-

--- a/Tutorial/4-Add Search/RazorPagesMovie/Startup.cs
+++ b/Tutorial/4-Add Search/RazorPagesMovie/Startup.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using RazorPagesMovie.Models;
 
 namespace RazorPagesMovie
@@ -23,8 +25,16 @@ namespace RazorPagesMovie
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
+            });
+
             services.AddDbContext<MovieContext>(options => options.UseSqlite(Configuration.GetConnectionString("MovieContext")));
-            services.AddMvc();
+            services.AddMvc()
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);       
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -37,9 +47,12 @@ namespace RazorPagesMovie
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseHsts();
             }
 
             app.UseStaticFiles();
+            app.UseHttpsRedirection();
+            app.UseCookiePolicy();
 
             app.UseMvc(routes =>
             {

--- a/Tutorial/4-Add Search/SearchPage.md
+++ b/Tutorial/4-Add Search/SearchPage.md
@@ -121,7 +121,7 @@ public async Task OnGetAsync(string movieGenre,string searchString)
 
 ![](https://github.com/dotnet-presentations/aspnetcore-for-beginners/blob/master/Tutorial/4-Add%20Search/images/genre.PNG)
 
-Mission Accomplished 
+Mission Accomplished
 
 ![](https://media.giphy.com/media/3o6UBbrfvYwldawfDi/giphy.gif)
 


### PR DESCRIPTION
Updates based on https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-2.1
- [x]  Update project to 2.1
- [x]  Update instructions
    - [x] Tutorial 1
    - [x] Tutorial 2
        - Removed "Add the Entity Framework tools" step, no longer needed
        - Typo Fix
    - [x] Tutorial 3
    - [x] Tutorial 4
